### PR TITLE
Make chatbot::query_chat compute intensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Open <http://localhost:3000/> in your browser.
 - [x] Warmup
 - [x] Async and Await
 - [x] Joining Futures
+- [x] Spawning Tasks

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn gen_random_number() -> usize {
 ///
 /// Warning: may take a few seconds!
 pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    std::thread::sleep(Duration::from_secs(2));
     let most_recent = messages.last().unwrap();
     vec![
         format!("\"{most_recent}\"? And how does that make you feel?"),


### PR DESCRIPTION
"Improvements" to our "language model" have required it to become more computationally intensive. This is represented by `tokio::time::sleep` (a non-blocking operation) changing into `std::thread::sleep` (a blocking operation).

Resolves #7. (Don't merge until you've added your solution!)
