### PR TITLE
Add support for retrieval-augmented generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Open <http://localhost:3000/> in your browser.
 - [x] Joining Futures
 - [x] Spawning Tasks
 - [x] Message Passing
+- [x] Waiting on Many Futures

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -1,5 +1,5 @@
 use rand::{rngs::SmallRng, Rng, SeedableRng};
-use std::{cell::RefCell, time::Duration};
+use std::{cell::RefCell, path::PathBuf, time::Duration};
 
 thread_local! {
     static RNG: RefCell<SmallRng> = RefCell::new(SmallRng::from_entropy());
@@ -33,10 +33,17 @@ impl Chatbot {
         }
     }
 
+    pub fn retrieval_documents(&self, _messages: &[String]) -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("data/doc1.txt"),
+            PathBuf::from("data/doc2.txt"),
+        ]
+    }
+
     /// Generates a list of possible responses given the current chat.
     ///
     /// Warning: may take a few seconds!
-    pub async fn query_chat(&mut self, messages: &[String]) -> Vec<String> {
+    pub async fn query_chat(&mut self, messages: &[String], docs: &[String]) -> Vec<String> {
         std::thread::sleep(Duration::from_secs(2));
         let most_recent = messages.last().unwrap();
         let emoji = &self.emojis[self.emoji_counter];
@@ -44,6 +51,8 @@ impl Chatbot {
         vec![
             format!("\"{most_recent}\"? And how does that make you feel? {emoji}",),
             format!("\"{most_recent}\"! Interesting! Go on... {emoji}"),
+            format!("Have you considered: {}", docs.first().unwrap()),
+            format!("I might recommend: {}", docs.last().unwrap()),
         ]
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,10 +1,14 @@
-use std::sync::{Arc, LazyLock};
+use std::{
+    path::PathBuf,
+    sync::{Arc, LazyLock},
+};
 
 use miniserve::{http::StatusCode, Content, Request, Response};
 use serde::{Deserialize, Serialize};
 use tokio::{
-    join,
+    fs, join,
     sync::{mpsc, oneshot},
+    task::JoinSet,
 };
 
 async fn index(_req: Request) -> Response {
@@ -17,19 +21,36 @@ struct Messages {
     messages: Vec<String>,
 }
 
-async fn query_chat(messages: &Arc<Vec<String>>) -> Vec<String> {
-    type Payload = (Arc<Vec<String>>, oneshot::Sender<Vec<String>>);
-    static SENDER: LazyLock<mpsc::Sender<Payload>> = LazyLock::new(|| {
-        let (tx, mut rx) = mpsc::channel::<Payload>(1024);
-        tokio::spawn(async move {
-            let mut chatbot = chatbot::Chatbot::new(vec![":-)".into(), "^^".into()]);
-            while let Some((messages, responder)) = rx.recv().await {
-                let response = chatbot.query_chat(&messages).await;
-                responder.send(response).unwrap();
-            }
-        });
-        tx
+async fn load_docs(paths: Vec<PathBuf>) -> Vec<String> {
+    let mut doc_futs = paths
+        .into_iter()
+        .map(fs::read_to_string)
+        .collect::<JoinSet<_>>();
+    let mut docs = Vec::new();
+    while let Some(result) = doc_futs.join_next().await {
+        docs.push(result.unwrap().unwrap());
+    }
+    docs
+}
+
+type Payload = (Arc<Vec<String>>, oneshot::Sender<Vec<String>>);
+
+fn chatbot_thread() -> mpsc::Sender<Payload> {
+    let (tx, mut rx) = mpsc::channel::<Payload>(1024);
+    tokio::spawn(async move {
+        let mut chatbot = chatbot::Chatbot::new(vec![":-)".into(), "^^".into()]);
+        while let Some((messages, responder)) = rx.recv().await {
+            let doc_paths = chatbot.retrieval_documents(&messages);
+            let docs = load_docs(doc_paths).await;
+            let response = chatbot.query_chat(&messages, &docs).await;
+            responder.send(response).unwrap();
+        }
     });
+    tx
+}
+
+async fn query_chat(messages: &Arc<Vec<String>>) -> Vec<String> {
+    static SENDER: LazyLock<mpsc::Sender<Payload>> = LazyLock::new(chatbot_thread);
 
     let (tx, rx) = oneshot::channel();
     SENDER.send((Arc::clone(messages), tx)).await.unwrap();

--- a/data/doc1.txt
+++ b/data/doc1.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/data/doc2.txt
+++ b/data/doc2.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet.


### PR DESCRIPTION
Makes two changes to the chatbot API:
1. Add the `retrieval_documents` methods which returns a vector of paths to retrieve from given the current conversation context.
2. Adds the `docs` parameter to `query_chat` which should take the content of the documents specified by `retrieval_documents`.

Resolves #11. (Don't merge until you've added your solution!)
