### PR TITLE
Add frontend support for cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Open <http://localhost:3000/> in your browser.
 - [x] Spawning Tasks
 - [x] Message Passing
 - [x] Waiting on Many Futures
+- [x] Selecting Between Futures

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -44,7 +44,7 @@ impl Chatbot {
     ///
     /// Warning: may take a few seconds!
     pub async fn query_chat(&mut self, messages: &[String], docs: &[String]) -> Vec<String> {
-        std::thread::sleep(Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_secs(2)).await;
         let most_recent = messages.last().unwrap();
         let emoji = &self.emojis[self.emoji_counter];
         self.emoji_counter = (self.emoji_counter + 1) % self.emojis.len();

--- a/crates/server/index.html
+++ b/crates/server/index.html
@@ -26,6 +26,7 @@
     <form id="input">
       <input type="text" />
       <input type="submit" />
+      <button id="cancel" type="button">Cancel</button>
       <span id="spinner"></span>
     </form>
     <div id="messages"></div>
@@ -35,6 +36,7 @@
       let msgContainer = document.getElementById("messages");
       let textEl = document.querySelector("form input[type=text]");
       let spinnerEl = document.getElementById("spinner");
+      let cancelEl = document.getElementById("cancel");
 
       async function fetchChat(chat) {
         spinnerEl.classList.add("active");
@@ -46,7 +48,13 @@
             body: JSON.stringify(chat)
           });
           if (!response.ok) throw new Error(response.statusText);
-          return await response.json();
+          let json = await response.json();
+          if (json.type === "Success") {
+            return json;
+          } else {
+            alert("Cancelled");
+            throw new Error("Cancelled");
+          }
         } finally {
           spinnerEl.classList.remove("active");
           textEl.removeAttribute("disabled");
@@ -65,11 +73,13 @@
         event.preventDefault();
         chat.messages.push(textEl.value);
         textEl.value = "";
+        updateChat(chat);
         fetchChat(chat).then(updateChat);
       }
 
       function main() {
         document.getElementById("input").addEventListener("submit", onSubmit);        
+        cancelEl.addEventListener("click", () => fetch("/cancel", {method: "post"}));
       }
 
       main();

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -56,7 +56,7 @@ fn chatbot_thread() -> (mpsc::Sender<Payload>, mpsc::Sender<()>) {
                 response = chat_fut => {
                     responder.send(Some(response)).unwrap();
                 }
-                _ = cancel_fut => {                    
+                _ = cancel_fut => {
                     responder.send(None).unwrap();
                 }
             }
@@ -106,7 +106,7 @@ async fn chat(req: Request) -> Response {
         }
         None => MessagesResponse::Cancelled,
     };
-    
+
     Ok(Content::Json(serde_json::to_string(&response).unwrap()))
 }
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -17,8 +17,15 @@ async fn index(_req: Request) -> Response {
 }
 
 #[derive(Serialize, Deserialize)]
-struct Messages {
+struct MessagesRequest {
     messages: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+enum MessagesResponse {
+    Success { messages: Vec<String> },
+    Cancelled,
 }
 
 async fn load_docs(paths: Vec<PathBuf>) -> Vec<String> {
@@ -33,46 +40,74 @@ async fn load_docs(paths: Vec<PathBuf>) -> Vec<String> {
     docs
 }
 
-type Payload = (Arc<Vec<String>>, oneshot::Sender<Vec<String>>);
+type Payload = (Arc<Vec<String>>, oneshot::Sender<Option<Vec<String>>>);
 
-fn chatbot_thread() -> mpsc::Sender<Payload> {
-    let (tx, mut rx) = mpsc::channel::<Payload>(1024);
+fn chatbot_thread() -> (mpsc::Sender<Payload>, mpsc::Sender<()>) {
+    let (req_tx, mut req_rx) = mpsc::channel::<Payload>(1024);
+    let (cancel_tx, mut cancel_rx) = mpsc::channel::<()>(1);
     tokio::spawn(async move {
         let mut chatbot = chatbot::Chatbot::new(vec![":-)".into(), "^^".into()]);
-        while let Some((messages, responder)) = rx.recv().await {
+        while let Some((messages, responder)) = req_rx.recv().await {
             let doc_paths = chatbot.retrieval_documents(&messages);
             let docs = load_docs(doc_paths).await;
-            let response = chatbot.query_chat(&messages, &docs).await;
-            responder.send(response).unwrap();
+            let chat_fut = chatbot.query_chat(&messages, &docs);
+            let cancel_fut = cancel_rx.recv();
+            tokio::select! {
+                response = chat_fut => {
+                    responder.send(Some(response)).unwrap();
+                }
+                _ = cancel_fut => {                    
+                    responder.send(None).unwrap();
+                }
+            }
         }
     });
-    tx
+    (req_tx, cancel_tx)
 }
 
-async fn query_chat(messages: &Arc<Vec<String>>) -> Vec<String> {
-    static SENDER: LazyLock<mpsc::Sender<Payload>> = LazyLock::new(chatbot_thread);
+static CHATBOT_THREAD: LazyLock<(mpsc::Sender<Payload>, mpsc::Sender<()>)> =
+    LazyLock::new(chatbot_thread);
 
+async fn query_chat(messages: &Arc<Vec<String>>) -> Option<Vec<String>> {
     let (tx, rx) = oneshot::channel();
-    SENDER.send((Arc::clone(messages), tx)).await.unwrap();
+    CHATBOT_THREAD
+        .0
+        .send((Arc::clone(messages), tx))
+        .await
+        .unwrap();
     rx.await.unwrap()
+}
+
+async fn cancel(_req: Request) -> Response {
+    CHATBOT_THREAD.1.send(()).await.unwrap();
+    Ok(Content::Html("success".into()))
 }
 
 async fn chat(req: Request) -> Response {
     let Request::Post(body) = req else {
         return Err(StatusCode::METHOD_NOT_ALLOWED);
     };
-    let Ok(mut data) = serde_json::from_str::<Messages>(&body) else {
+    let Ok(mut data) = serde_json::from_str::<MessagesRequest>(&body) else {
         return Err(StatusCode::INTERNAL_SERVER_ERROR);
     };
 
     let messages = Arc::new(data.messages);
-    let (i, mut responses) = join!(chatbot::gen_random_number(), query_chat(&messages));
+    let (i, responses_opt) = join!(chatbot::gen_random_number(), query_chat(&messages));
 
-    let response = responses.remove(i % responses.len());
-    data.messages = Arc::into_inner(messages).unwrap();
-    data.messages.push(response);
+    let response = match responses_opt {
+        Some(mut responses) => {
+            let response = responses.remove(i % responses.len());
+            data.messages = Arc::into_inner(messages).unwrap();
+            data.messages.push(response);
 
-    Ok(Content::Json(serde_json::to_string(&data).unwrap()))
+            MessagesResponse::Success {
+                messages: data.messages,
+            }
+        }
+        None => MessagesResponse::Cancelled,
+    };
+    
+    Ok(Content::Json(serde_json::to_string(&response).unwrap()))
 }
 
 #[tokio::main]
@@ -80,6 +115,7 @@ async fn main() {
     miniserve::Server::new()
         .route("/", index)
         .route("/chat", chat)
+        .route("/cancel", cancel)
         .run()
         .await
 }


### PR DESCRIPTION
Adds a button to the frontend which allows users to cancel running computations. Specifically, when a user hits "Cancel", this posts the `/cancel` route. The `/chat` route is expected to return a `type` field of either `"Success"` or `"Cancelled"`.

Resolves #13. (Don't merge until you've added your solution!)
